### PR TITLE
Disallow Short Echos 1.x

### DIFF
--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -59,7 +59,7 @@
        functions, methods, if, elseif, foreach, for, and switch blocks. -->
     <rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
 
-    <!-- No short echos allowed. WordPress-VIP-GO overides the default 
+    <!-- No short echos allowed. WordPress-VIP-GO overrides the default 
         severity.  -->
     <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
         <severity>4</severity>

--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -59,13 +59,6 @@
        functions, methods, if, elseif, foreach, for, and switch blocks. -->
     <rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
 
-    <!-- No short echos allowed. WordPress-VIP-GO overrides the default 
-        severity.  -->
-    <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
-        <severity>4</severity>
-        <type>warning</type>
-    </rule>
-
     <!-- Generic / Squiz -->
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>
@@ -95,6 +88,11 @@
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <!-- Forbid deprecated functions -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <!-- No short echos allowed. <?= $var; ?>  -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+        <severity>4</severity>
+        <type>warning</type>
+    </rule>
 
     <!-- Slevomat class formatting -->
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>

--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -88,7 +88,7 @@
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <!-- Forbid deprecated functions -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <!-- No short echos allowed. <?= $var; ?>  -->
+    <!-- Disable short echo tags. <?= $var; ?> -->
     <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
         <severity>4</severity>
         <type>warning</type>

--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -62,9 +62,9 @@
     <!-- No short echos allowed. WordPress-VIP-GO overides the default 
         severity.  -->
     <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
-		<severity>4</severity>
+        <severity>4</severity>
         <type>warning</type>
-	</rule>
+    </rule>
 
     <!-- Generic / Squiz -->
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>

--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -59,6 +59,13 @@
        functions, methods, if, elseif, foreach, for, and switch blocks. -->
     <rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
 
+    <!-- No short echos allowed. WordPress-VIP-GO overides the default 
+        severity.  -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+		<severity>4</severity>
+        <type>warning</type>
+	</rule>
+
     <!-- Generic / Squiz -->
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>


### PR DESCRIPTION
Re-enables the disallow short echo rule overwritten by [WordPress-VIP-Go](https://github.com/Automattic/VIP-Coding-Standards/blob/9286daa3973ddd5b4831a95c15617c05158cd924/WordPress-VIP-Go/ruleset.xml#L263).