### PR TITLE
Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,8 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "automattic/vipwpcs": "*",
+        "automattic/vipwpcs": "^3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 | ^1.0",
-        "cweagans/composer-patches": "^1.7",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "slevomat/coding-standard": "^8.0",
         "squizlabs/php_codesniffer": "^3.6"
@@ -30,8 +29,7 @@
     "config": {
       "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "cweagans/composer-patches": true
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,5 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "cweagans/composer-patches": true
         }
-    },
-    "extra": {
-      "enable-patching": true,
-      "patches": {
-        "wp-coding-standards/wpcs": {
-          "Add PHP 8 support until WordPress releases a new version": "https://github.com/WordPress/WordPress-Coding-Standards/commit/7cd46bed1e6a7a2af3fe24c7f4a044da3076d8f4.patch"
-        }
-      }
     }
 }

--- a/lib/ModernTribe/ruleset.xml
+++ b/lib/ModernTribe/ruleset.xml
@@ -53,7 +53,7 @@
 	<rule ref="WordPressVIPMinimum">
 		<severity>3</severity>
 		<exclude name="WordPressVIPMinimum.Constants.ConstantString.NotCheckingConstantName" />
-		<exclude name="WordPressVIPMinimum.Variables.VariableAnalysis" />
+		<exclude name="VariableAnalysis" />
 	</rule>
 	<!-- Covers rule: Put spaces on both sides of the opening and closing parenthesis of
 		   functions, methods, if, elseif, foreach, for, and switch blocks. -->


### PR DESCRIPTION
- Remove `WordPressVIPMinimum.Variables.VariableAnalysis` sniff because it's deprecated & replace with `VariableAnalysis`, which is now a dependency.
- Remove patch for PHP8, which I believe is no longer needed from the discovery I did. It was throwing an error that the patch could not be applied for projects & I believe that when WPCS as updated to 3.0 it is no longer needed.